### PR TITLE
Fix link to where to file issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,7 +273,7 @@ https://hnrss.org/frontpage.atom
 # "Ask HN" with 10 or more comments as JSON Feed
 https://hnrss.org/ask.jsonfeed?comments=10
 </pre>
-<p>Note: These formats are a lot less battle-tested than the RSS format. If you see any wonkiness or they don’t play nicely with your feed reader, please <a href="https://github.com/edavis/hnrss/issues/new">open an issue</a> with as much information as possible. Thanks!</p>
+<p>Note: These formats are a lot less battle-tested than the RSS format. If you see any wonkiness or they don’t play nicely with your feed reader, please <a href="https://github.com/hnrss/hnrss/issues/new">open an issue</a> with as much information as possible. Thanks!</p>
 
 <h2 id="support">Support</h2>
 <p>If hnrss.org has made your job or hobby project easier, and you want to show some gratitude, <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=ZP9Q7QUNS3QYY">donations are very much appreciated</a>.</p>


### PR DESCRIPTION
this was still pointing to the old repo (where you also can't open issues now)