### PR TITLE
Add link to HN Best summarized with ChatGPT

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,6 +149,10 @@ https://hnrss.org/classic
 <pre>
 https://hnrss.org/best
 </pre>
+<p>Hacker News <a href="https://news.ycombinator.com/best">Best</a> (same as the previous feed) but all articles are summarized with ChatGPT:</p>
+<pre>
+https://notifier.in/rss/best_hackernews_summarized.xml
+</pre>
 <p>Hacker News <a href="https://news.ycombinator.com/invited">Invited</a> and <a href="https://news.ycombinator.com/pool">Pool</a> for reposted stories invited back by the mods and given a <a href="https://news.ycombinator.com/item?id=26998308">second chance</a>:</p>
 <pre>
 https://hnrss.org/invited


### PR DESCRIPTION
As an avid HN reader, it's too time-consuming to keep up with all of HN's top articles. So I created an RSS feed where every article from https://hnrss.org/best is summarized via ChatGPT.

You can check it here: https://notifier.in/rss/best_hackernews_summarized.xml 

In this PR, I went ahead and added this URL to https://hnrss.org If you don’t think it belongs there, you can just close the PR. No hard feelings :-)

And thanks for the great service, by the way! I've been using it for several years now.

